### PR TITLE
Server side pagination

### DIFF
--- a/src/client/components/ThesisPage/ThesesPage.tsx
+++ b/src/client/components/ThesisPage/ThesesPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@backend/types'
 import { Box, Stack, TextField, Typography } from '@mui/material'
 
-import { useTheses } from '../../hooks/useTheses'
+import { usePaginatedTheses } from '../../hooks/useTheses'
 import useLoggedInUser from '../../hooks/useLoggedInUser'
 import {
   useCreateThesisMutation,
@@ -59,7 +59,7 @@ const ThesesPage = () => {
     theses,
     totalCount,
     isLoading: isThesesLoading,
-  } = useTheses({
+  } = usePaginatedTheses({
     onlySupervised: showOnlyOwnTheses,
     offset: paginationModel.page * paginationModel.pageSize,
     limit: paginationModel.pageSize,

--- a/src/client/components/ThesisPage/ThesesPage.tsx
+++ b/src/client/components/ThesisPage/ThesesPage.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import {
@@ -55,7 +55,11 @@ const ThesesPage = () => {
   const [newThesis, setNewThesis] = useState<Thesis | null>(null)
   const [showOnlyOwnTheses, setShowOnlyOwnTheses] = useState(true)
 
-  const { theses, isLoading: isThesesLoading } = useTheses({
+  const {
+    theses,
+    totalCount,
+    isLoading: isThesesLoading,
+  } = useTheses({
     onlySupervised: showOnlyOwnTheses,
     offset: paginationModel.page * paginationModel.pageSize,
     limit: paginationModel.pageSize,
@@ -67,7 +71,14 @@ const ThesesPage = () => {
   const { mutateAsync: deleteThesis } = useDeleteThesisMutation()
   const { mutateAsync: createThesis } = useCreateThesisMutation()
 
-  const rowCount = isThesesLoading ? 0 : theses.length
+  const rowCountRef = useRef(totalCount || 0)
+
+  const rowCount = useMemo(() => {
+    if (totalCount !== undefined) {
+      rowCountRef.current = totalCount
+    }
+    return rowCountRef.current
+  }, [totalCount])
 
   const columns: GridColDef<Thesis>[] = [
     {

--- a/src/client/components/ThesisPage/ThesesPage.tsx
+++ b/src/client/components/ThesisPage/ThesesPage.tsx
@@ -34,7 +34,7 @@ import { getSortedByName } from './util'
 
 import { StatusLocale } from '../../types'
 
-const PAGE_SIZE = 5
+const PAGE_SIZE = 25
 
 const ThesesPage = () => {
   const { t, i18n } = useTranslation()

--- a/src/client/components/ThesisPage/ThesesPage.tsx
+++ b/src/client/components/ThesisPage/ThesesPage.tsx
@@ -34,10 +34,17 @@ import { getSortedByName } from './util'
 
 import { StatusLocale } from '../../types'
 
+const PAGE_SIZE = 5
+
 const ThesesPage = () => {
   const { t, i18n } = useTranslation()
   const { language } = i18n as { language: TranslationLanguage }
   const { user, isLoading: loggedInUserLoading } = useLoggedInUser()
+
+  const [paginationModel, setPaginationModel] = useState({
+    page: 0,
+    pageSize: PAGE_SIZE,
+  })
 
   const [rowSelectionModel, setRowSelectionModel] =
     useState<GridRowSelectionModel>([])
@@ -50,6 +57,8 @@ const ThesesPage = () => {
 
   const { theses, isLoading: isThesesLoading } = useTheses({
     onlySupervised: showOnlyOwnTheses,
+    offset: paginationModel.page * paginationModel.pageSize,
+    limit: paginationModel.pageSize,
   })
   const { programs, isLoading: isProgramLoading } = usePrograms({
     includeNotManaged: true,
@@ -57,6 +66,8 @@ const ThesesPage = () => {
   const { mutateAsync: editThesis } = useEditThesisMutation()
   const { mutateAsync: deleteThesis } = useDeleteThesisMutation()
   const { mutateAsync: createThesis } = useCreateThesisMutation()
+
+  const rowCount = isThesesLoading ? 0 : theses.length
 
   const columns: GridColDef<Thesis>[] = [
     {
@@ -200,16 +211,13 @@ const ThesesPage = () => {
           loading={isLoading}
           rows={isLoading ? skeletonRows : theses}
           columns={columns}
-          initialState={{
-            pagination: {
-              paginationModel: {
-                pageSize: 100,
-              },
-            },
-          }}
           autoHeight
           hideFooterSelectedRowCount
-          pageSizeOptions={[100]}
+          pageSizeOptions={[PAGE_SIZE]}
+          paginationMode="server"
+          paginationModel={paginationModel}
+          onPaginationModelChange={(newModel) => setPaginationModel(newModel)}
+          rowCount={rowCount}
           getRowHeight={() => 44}
           columnHeaderHeight={36}
           rowSelectionModel={rowSelectionModel}

--- a/src/client/hooks/useTheses.ts
+++ b/src/client/hooks/useTheses.ts
@@ -22,7 +22,7 @@ export const useTheses = (params: UseThesesParams) => {
     theses: ThesisData[]
     totalCount: number
   }> => {
-    const { data } = await apiClient.get('/theses', { params })
+    const { data } = await apiClient.get('/theses/paginate', { params })
 
     return data
   }

--- a/src/client/hooks/useTheses.ts
+++ b/src/client/hooks/useTheses.ts
@@ -5,16 +5,23 @@ import { ThesisData } from '@backend/types'
 
 import apiClient from '../util/apiClient'
 
-interface UseThesesOptions {
+interface UseThesesParams {
   onlySupervised: boolean
+  offset: number
+  limit: number
 }
-export const useTheses = ({ onlySupervised }: UseThesesOptions) => {
-  const queryKey = ['theses', onlySupervised]
+export const useTheses = (params: UseThesesParams) => {
+  const queryKey = [
+    'theses',
+    params.onlySupervised,
+    params.offset,
+    params.limit,
+  ]
 
   const queryFn = async (): Promise<ThesisData[]> => {
-    const { data } = await apiClient.get(
-      `/theses${onlySupervised ? '?onlySupervised=true' : ''}`
-    )
+    const { data } = await apiClient.get('/theses', { params })
+
+    console.log(params)
 
     return data
   }

--- a/src/client/hooks/useTheses.ts
+++ b/src/client/hooks/useTheses.ts
@@ -7,10 +7,31 @@ import apiClient from '../util/apiClient'
 
 interface UseThesesParams {
   onlySupervised: boolean
+}
+
+export const useTheses = ({ onlySupervised }: UseThesesParams) => {
+  const queryKey = ['theses', onlySupervised]
+
+  const queryFn = async (): Promise<ThesisData[]> => {
+    const { data } = await apiClient.get(
+      `/theses${onlySupervised ? '?onlySupervised=true' : ''}`
+    )
+
+    return data
+  }
+
+  const { data: theses, ...rest } = useQuery({ queryKey, queryFn })
+
+  return { theses, ...rest }
+}
+
+interface UsePaginatedThesesParams {
+  onlySupervised: boolean
   offset: number
   limit: number
 }
-export const useTheses = (params: UseThesesParams) => {
+
+export const usePaginatedTheses = (params: UsePaginatedThesesParams) => {
   const queryKey = [
     'theses',
     params.onlySupervised,
@@ -29,7 +50,7 @@ export const useTheses = (params: UseThesesParams) => {
 
   const { data, ...rest } = useQuery({ queryKey, queryFn })
 
-  return { ...data, ...rest }
+  return { theses: data?.theses, totalCount: data?.totalCount, ...rest }
 }
 
 export const useSingleThesis = (id: string | GridRowSelectionModel) => {

--- a/src/client/hooks/useTheses.ts
+++ b/src/client/hooks/useTheses.ts
@@ -18,17 +18,18 @@ export const useTheses = (params: UseThesesParams) => {
     params.limit,
   ]
 
-  const queryFn = async (): Promise<ThesisData[]> => {
+  const queryFn = async (): Promise<{
+    theses: ThesisData[]
+    totalCount: number
+  }> => {
     const { data } = await apiClient.get('/theses', { params })
-
-    console.log(params)
 
     return data
   }
 
-  const { data: theses, ...rest } = useQuery({ queryKey, queryFn })
+  const { data, ...rest } = useQuery({ queryKey, queryFn })
 
-  return { theses, ...rest }
+  return { ...data, ...rest }
 }
 
 export const useSingleThesis = (id: string | GridRowSelectionModel) => {

--- a/src/server/routes/thesis.integration-test.js
+++ b/src/server/routes/thesis.integration-test.js
@@ -611,6 +611,83 @@ describe('thesis router', () => {
           })
         })
 
+        describe('when the teacher user fetches paginated own theses', () => {
+          let thesis5
+
+          beforeEach(async () => {
+            thesis5 = await Thesis.create({
+              programId: 'Testing program',
+              studyTrackId: 'test-study-track-id',
+              topic: 'test topic',
+              status: 'PLANNING',
+              startDate: '1970-01-01',
+              targetDate: '2070-01-01',
+            })
+
+            await Supervision.create({
+              userId: teacherUser.id,
+              thesisId: thesis5.id,
+              percentage: 100,
+              isPrimarySupervisor: true,
+            })
+          })
+
+          it('should return the first page of theses', async () => {
+            const response = await request
+              .get('/api/theses/paginate?onlySupervised=true&&offset=0&limit=1')
+              .set({ uid: teacherUser.id, hygroupcn: 'hy-employees' })
+
+            expect(response.status).toEqual(200)
+            expect(response.body.totalCount).toBe(2)
+            expect(response.body.theses).toMatchObject([
+              {
+                id: thesis2.id,
+                programId: 'Testing program',
+                studyTrackId: 'test-study-track-id',
+                topic: 'test topic',
+                status: 'PLANNING',
+                startDate: '1970-01-01T00:00:00.000Z',
+                targetDate: '2070-01-01T00:00:00.000Z',
+                supervisions: [
+                  {
+                    user: teacherUser,
+                    percentage: 100,
+                    isPrimarySupervisor: true,
+                  },
+                ],
+              },
+            ])
+          })
+
+          it('should return the second page of theses', async () => {
+            const response = await request
+              .get('/api/theses/paginate?onlySupervised=true&&offset=1&limit=1')
+              .set({ uid: teacherUser.id, hygroupcn: 'hy-employees' })
+
+            expect(response.status).toEqual(200)
+            expect(response.body.totalCount).toBe(2)
+            expect(response.body.theses).toMatchObject([
+              {
+                id: thesis5.id,
+                programId: 'Testing program',
+                studyTrackId: 'test-study-track-id',
+                topic: 'test topic',
+                status: 'PLANNING',
+                startDate: '1970-01-01T00:00:00.000Z',
+                targetDate: '2070-01-01T00:00:00.000Z',
+                supervisions: [
+                  {
+                    user: teacherUser,
+                    percentage: 100,
+                    isPrimarySupervisor: true,
+                  },
+                ],
+              },
+            ])
+          })
+        })
+
+
         describe('when the program manager user fetches own theses', () => {
           it('should return all theses supervised by the user, but not the others in the managed program', async () => {
             const response = await request
@@ -638,6 +715,84 @@ describe('thesis router', () => {
           })
         })
 
+        describe('when the program manager user fetches paginated own theses', () => {
+          let thesis6
+
+          beforeEach(async () => {
+            thesis6 = await Thesis.create({
+              programId: 'Testing program',
+              studyTrackId: 'test-study-track-id',
+              topic: 'test topic',
+              status: 'PLANNING',
+              startDate: '1970-01-01',
+              targetDate: '2070-01-01',
+            })
+
+            await Supervision.create({
+              userId: programManagerUser.id,
+              thesisId: thesis6.id,
+              percentage: 100,
+              isPrimarySupervisor: true,
+            })
+          })
+
+          it('should return the first page of theses', async () => {
+            const response = await request
+              .get('/api/theses/paginate?onlySupervised=true&&offset=0&limit=1')
+              .set({ uid: programManagerUser.id, hygroupcn: 'hy-employees' })
+
+            expect(response.status).toEqual(200)
+            expect(response.body.totalCount).toBe(2)
+            expect(response.body.theses).toMatchObject([
+              {
+                id: thesis3.id,
+                programId: 'Testing program',
+                studyTrackId: 'test-study-track-id',
+                topic: 'test topic',
+                status: 'PLANNING',
+                startDate: '1970-01-01T00:00:00.000Z',
+                targetDate: '2070-01-01T00:00:00.000Z',
+                supervisions: [
+                  {
+                    user: programManagerUser,
+                    percentage: 100,
+                    isPrimarySupervisor: true,
+                  },
+                ],
+              },
+            ])
+          })
+
+          it('should return the second page of theses', async () => {
+            const response = await request
+              .get('/api/theses/paginate?onlySupervised=true&&offset=1&limit=1')
+              .set({ uid: programManagerUser.id, hygroupcn: 'hy-employees' })
+
+            expect(response.status).toEqual(200)
+            expect(response.body.totalCount).toBe(2)
+            expect(response.body.theses).toMatchObject([
+              {
+                id: thesis6.id,
+                programId: 'Testing program',
+                studyTrackId: 'test-study-track-id',
+                topic: 'test topic',
+                status: 'PLANNING',
+                startDate: '1970-01-01T00:00:00.000Z',
+                targetDate: '2070-01-01T00:00:00.000Z',
+                supervisions: [
+                  {
+                    user: programManagerUser,
+                    percentage: 100,
+                    isPrimarySupervisor: true,
+                  },
+                ],
+              },
+            ])
+          })
+        })
+
+
+
         describe('when an admin user fetches own theses', () => {
           it('should return all theses supervised by the user and only those', async () => {
             const response = await request
@@ -664,6 +819,84 @@ describe('thesis router', () => {
             ])
           })
         })
+
+        describe('when the admin user fetches paginated own theses', () => {
+          let thesis7
+
+          beforeEach(async () => {
+            thesis7 = await Thesis.create({
+              programId: 'Testing program',
+              studyTrackId: 'test-study-track-id',
+              topic: 'test topic',
+              status: 'PLANNING',
+              startDate: '1970-01-01',
+              targetDate: '2070-01-01',
+            })
+
+            await Supervision.create({
+              userId: adminUser.id,
+              thesisId: thesis7.id,
+              percentage: 100,
+              isPrimarySupervisor: true,
+            })
+          })
+
+          it('should return the first page of theses', async () => {
+            const response = await request
+              .get('/api/theses/paginate?onlySupervised=true&&offset=0&limit=1')
+              .set({ uid: adminUser.id, hygroupcn: 'grp-toska' })
+
+            expect(response.status).toEqual(200)
+            expect(response.body.totalCount).toBe(2)
+            expect(response.body.theses).toMatchObject([
+              {
+                id: thesis4.id,
+                programId: 'Testing program',
+                studyTrackId: 'test-study-track-id',
+                topic: 'test topic',
+                status: 'PLANNING',
+                startDate: '1970-01-01T00:00:00.000Z',
+                targetDate: '2070-01-01T00:00:00.000Z',
+                supervisions: [
+                  {
+                    user: adminUser,
+                    percentage: 100,
+                    isPrimarySupervisor: true,
+                  },
+                ],
+              },
+            ])
+          })
+
+          it('should return the second page of theses', async () => {
+            const response = await request
+              .get('/api/theses/paginate?onlySupervised=true&&offset=1&limit=1')
+              .set({ uid: adminUser.id, hygroupcn: 'grp-toska' })
+
+            expect(response.status).toEqual(200)
+            expect(response.body.totalCount).toBe(2)
+            expect(response.body.theses).toMatchObject([
+              {
+                id: thesis7.id,
+                programId: 'Testing program',
+                studyTrackId: 'test-study-track-id',
+                topic: 'test topic',
+                status: 'PLANNING',
+                startDate: '1970-01-01T00:00:00.000Z',
+                targetDate: '2070-01-01T00:00:00.000Z',
+                supervisions: [
+                  {
+                    user: adminUser,
+                    percentage: 100,
+                    isPrimarySupervisor: true,
+                  },
+                ],
+              },
+            ])
+          })
+        })
+
+
       })
     })
 

--- a/src/server/routes/thesis.ts
+++ b/src/server/routes/thesis.ts
@@ -382,7 +382,8 @@ thesisRouter.get('/', async (req: ServerGetRequest, res: Response) => {
     order: [['targetDate', 'ASC']],
   })
 
-  const thesesData = transformThesisData(JSON.parse(JSON.stringify(theses)))
+  const thesesRows = theses.map((t) => t.toJSON()) as ThesisData[]
+  const thesesData = transformThesisData(thesesRows)
 
   res.send(thesesData)
 })
@@ -404,7 +405,8 @@ thesisRouter.get('/paginate', async (req: ServerGetRequest, res: Response) => {
     order: [['targetDate', 'ASC']],
   })
 
-  const theses = transformThesisData(JSON.parse(JSON.stringify(rows)))
+  const thesesRows = rows.map((t) => t.toJSON()) as ThesisData[]
+  const theses = transformThesisData(thesesRows)
 
   res.send({ theses, totalCount: count })
 })

--- a/src/server/routes/thesis.ts
+++ b/src/server/routes/thesis.ts
@@ -370,6 +370,25 @@ const deleteThesis = async (id: string, transaction: Transaction) => {
 
 // @ts-expect-error the user middleware updates the req object with user field
 thesisRouter.get('/', async (req: ServerGetRequest, res: Response) => {
+  const { onlySupervised } = req.query
+
+  const options = await getFindThesesOptions({
+    actionUser: req.user,
+    onlySupervised: onlySupervised === 'true',
+  })
+
+  const theses = await Thesis.findAll({
+    ...options,
+    order: [['targetDate', 'ASC']],
+  })
+
+  const thesesData = transformThesisData(JSON.parse(JSON.stringify(theses)))
+
+  res.send(thesesData)
+})
+
+// @ts-expect-error the user middleware updates the req object with user field
+thesisRouter.get('/paginate', async (req: ServerGetRequest, res: Response) => {
   const { onlySupervised, limit, offset } = req.query
 
   const options = await getFindThesesOptions({

--- a/src/server/routes/thesis.ts
+++ b/src/server/routes/thesis.ts
@@ -370,7 +370,7 @@ const deleteThesis = async (id: string, transaction: Transaction) => {
 thesisRouter.get('/', async (req: ServerGetRequest, res: Response) => {
   const options = await getFindThesesOptions({
     actionUser: req.user,
-    onlySupervised: Boolean(req.query.onlySupervised),
+    onlySupervised: req.query.onlySupervised === 'true',
   })
   const theses = await Thesis.findAll({
     ...options,


### PR DESCRIPTION
Implements the server side pagination for the theses table.

I created a separate route /api/theses/pagination which allows to paginate the theses results and left the old route pretty much as is to prevent breaking changes to the API.

Changed the useTheses hook to use the /paginate route -> Should it have been it's own hook, for example usePaginateTheses instead?

